### PR TITLE
Use itsdangerous library to sign cookie

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup
 
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
-setup(name="secure-cookie", install_requires=["Werkzeug>0.15"])
+setup(name="secure-cookie", install_requires=["Werkzeug>0.15", "itsdangerous"])

--- a/src/secure_cookie/cookie.py
+++ b/src/secure_cookie/cookie.py
@@ -309,6 +309,10 @@ class SecureCookie(ModificationTrackingDict):
         if isinstance(secret_key, text_type):
             secret_key = secret_key.encode("utf-8", "replace")
 
+        return cls._mac_unserialize(string, secret_key)
+
+    @classmethod
+    def _mac_unserialize(cls, string, secret_key):
         try:
             base64_hash, data = string.split(b"?", 1)
         except (ValueError, IndexError):

--- a/src/secure_cookie/cookie.py
+++ b/src/secure_cookie/cookie.py
@@ -292,7 +292,7 @@ class SecureCookie(ModificationTrackingDict):
                     )
                 ).encode("ascii")
             )
-        signer = Signer(self.secret_key)
+        signer = Signer(self.secret_key, digest_method=self.hash_method)
         return signer.sign(b"&".join(result))
 
     def _mac_serialize(self):
@@ -325,7 +325,7 @@ class SecureCookie(ModificationTrackingDict):
         if isinstance(secret_key, text_type):
             secret_key = secret_key.encode("utf-8", "replace")
 
-        signer = Signer(secret_key)
+        signer = Signer(secret_key, digest_method=cls.hash_method)
         try:
             serialized = signer.unsign(string)
         except BadSignature:

--- a/src/secure_cookie/cookie.py
+++ b/src/secure_cookie/cookie.py
@@ -100,6 +100,7 @@ API
 """
 import base64
 import json as _json
+import warnings
 from datetime import datetime
 from hashlib import sha1 as _default_hash
 from hmac import new as hmac
@@ -365,6 +366,7 @@ class SecureCookie(ModificationTrackingDict):
 
     @classmethod
     def _mac_unserialize(cls, string, secret_key):
+        warnings.warn("Obsolete serialization method used", DeprecationWarning)
         try:
             base64_hash, data = string.split(b"?", 1)
         except (ValueError, IndexError):

--- a/src/secure_cookie/cookie.py
+++ b/src/secure_cookie/cookie.py
@@ -280,6 +280,9 @@ class SecureCookie(ModificationTrackingDict):
         if expires:
             self["_expires"] = _date_to_unix(expires)
 
+        return self._mac_serialize()
+
+    def _mac_serialize(self):
         result = []
         mac = hmac(self.secret_key, None, self.hash_method)
 

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -51,6 +51,19 @@ def test_expire_support():
     assert "x" not in c3
 
 
+def test_hmac_serialization_support():
+    c = SecureCookie(secret_key=b"foo")
+    c["x"] = 42
+    s = c._mac_serialize()
+
+    c2 = SecureCookie.unserialize(s, b"foo")
+    assert c is not c2
+    assert not c2.new
+    assert not c2.modified
+    assert not c2.should_save
+    assert c2 == c
+
+
 def test_wrapper_support():
     req = Request.from_values()
     resp = Response()

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+import pytest
 from werkzeug.http import parse_cookie
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
@@ -26,7 +27,8 @@ def test_basic_support():
     assert not c2.should_save
     assert c2 == c
 
-    c3 = SecureCookie.unserialize(s, b"wrong foo")
+    with pytest.warns(DeprecationWarning):
+        c3 = SecureCookie.unserialize(s, b"wrong foo")
     assert not c3.modified
     assert not c3.new
     assert c3 == {}
@@ -56,7 +58,8 @@ def test_hmac_serialization_support():
     c["x"] = 42
     s = c._mac_serialize()
 
-    c2 = SecureCookie.unserialize(s, b"foo")
+    with pytest.warns(DeprecationWarning):
+        c2 = SecureCookie.unserialize(s, b"foo")
     assert c is not c2
     assert not c2.new
     assert not c2.modified


### PR DESCRIPTION
This PR is about issue https://github.com/pallets/secure-cookie/issues/6.

The previous serialization/deserialization is still in the code, until it will be removed in a another future release.

What do you think about it? Do you see improvements to add?
Perhaps the `itsdangerous` library version should be more restricted?