### PR TITLE
fix how pip is updated

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install -U wheel
           pip install -U setuptools
-          pip install -U pip
+          python -m pip install -U pip
       - name: get pip cache dir
         id: pip-cache
         run: echo "::set-output name=dir::$(pip cache dir)"
@@ -47,6 +47,6 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ matrix.python }}|${{ hashFiles('.pre-commit-config.yaml') }}
-        if: matrix.nox-session == 'style'
+        if: matrix.nox == 'style'
       - run: pip install nox
       - run: nox -s ${{ matrix.nox }}


### PR DESCRIPTION
Use `python -m pip install -U pip` to avoid a permission issue on Windows.