### PR TITLE
Fix spelling errors in code example

### DIFF
--- a/src/secure_cookie/session.py
+++ b/src/secure_cookie/session.py
@@ -60,10 +60,10 @@ as using the store directly.
 
 .. code-block:: python
 
-    from secure_cookie.sessions import FilesystemSessionStore
-    from secure_cookie.sessions import SessionMiddleware
+    from secure_cookie.session import FilesystemSessionStore
+    from secure_cookie.session import SessionMiddleware
 
-    session_store = FileSystemSessionStore()
+    session_store = FilesystemSessionStore()
     app = SessionMiddleware(app, session_store)
 
 


### PR DESCRIPTION
- remove the plural to session module name
- change 's' to lowercase in 'FilesystemSessionStore' (for 'system').