### PR TITLE
Update CI workflow to watch main branch instead of master

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,11 +2,11 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
       - '*.x'
   pull_request:
     branches:
-      - master
+      - main
       - '*.x'
 jobs:
   tests:


### PR DESCRIPTION
- [x] replace 'master' with 'main' in [tests.yml](https://github.com/pallets/secure-cookie/blob/main/.github/workflows/tests.yaml)

Tests failing due to `werkzeug.posixemulation import rename`. Fixed in #13