### PR TITLE
release 0.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
-Version 0.1.1
+Version 0.2.0
 -------------
 
-Unreleased
+Released 2021-08-17
 
--   Drop python 2.x and python 3.5 support. :pr:`62`
--   Replace ``posixemulation`` from Werkzeug 1.0.1 with ``os.rename``. :issue:`12`
+-   Drop Python 2 and 3.5 support. :pr:`62`
+-   Replace ``posixemulation`` from Werkzeug with ``os.replace``. :issue:`12`
 
 
 Version 0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = secure-cookie
-version = 0.1.0
+version = 0.2.0
 url = https://secure-cookie.readthedocs.io/
 project_urls =
     Documentation = https://secure-cookie.readthedocs.io/


### PR DESCRIPTION
Our 0.2.0 release 🎉 

This is a small release in order to get #13 out.

- [x] Drop python 2.x and 3.5
- [x] Fix #13 by replacing `posixemulation` with `os.rename`