### PR TITLE
FilesystemSessionStore create directories if they don't exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Version 0.x.y
+-------------
+
+Released 202
+
+-   ``FilesystemSessionStore`` tries to create ``path`` if the specified
+    location does not exist. :pr:`66`
+
+
 Version 0.2.0
 -------------
 

--- a/src/secure_cookie/cookie.py
+++ b/src/secure_cookie/cookie.py
@@ -257,11 +257,11 @@ class SecureCookie(ModificationTrackingDict):
                 value = cls.serialization_method.loads(value)
 
             return value
-        except Exception:
+        except Exception as exc:
             # Unfortunately serialization modules can cause pretty much
             # every error here. If we get one we catch it and convert it
             # into an UnquoteError.
-            raise UnquoteError()
+            raise UnquoteError() from exc
 
     def serialize(self, expires=None):
         """Serialize the secure cookie into a string.

--- a/src/secure_cookie/session.py
+++ b/src/secure_cookie/session.py
@@ -233,10 +233,10 @@ class FilesystemSessionStore(SessionStore):
     ):
         super(FilesystemSessionStore, self).__init__(session_class=session_class)
 
-        if path is None:
-            path = tempfile.gettempdir()
-        else:
+        if path:
             os.makedirs(path, exist_ok=True)
+        else:
+            path = tempfile.gettempdir()
 
         self.path = path
 

--- a/src/secure_cookie/session.py
+++ b/src/secure_cookie/session.py
@@ -88,7 +88,6 @@ import pickle
 import re
 import tempfile
 from hashlib import sha1
-from os import path
 from random import random
 from time import time
 
@@ -255,7 +254,7 @@ class FilesystemSessionStore(SessionStore):
         # Out of the box this should be a strict ASCII subset, but you
         # might reconfigure the session object to have a more arbitrary
         # string.
-        return path.join(self.path, self.filename_template % sid)
+        return str(pathlib.Path(self.path, self.filename_template % sid))
 
     def save(self, session):
         fn = self.get_session_filename(session.sid)

--- a/src/secure_cookie/session.py
+++ b/src/secure_cookie/session.py
@@ -235,6 +235,8 @@ class FilesystemSessionStore(SessionStore):
 
         if path is None:
             path = tempfile.gettempdir()
+        else:
+            os.makedirs(path, exist_ok=True)
 
         self.path = path
 

--- a/src/secure_cookie/session.py
+++ b/src/secure_cookie/session.py
@@ -83,6 +83,7 @@ API
     :members:
 """
 import os
+import pathlib
 import pickle
 import re
 import tempfile
@@ -234,7 +235,10 @@ class FilesystemSessionStore(SessionStore):
         super(FilesystemSessionStore, self).__init__(session_class=session_class)
 
         if path:
-            os.makedirs(path, exist_ok=True)
+            try:
+                pathlib.Path(path).mkdir(parents=True, exist_ok=True)
+            except OSError:
+                raise
         else:
             path = tempfile.gettempdir()
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -64,3 +64,12 @@ def test_fs_session_lising(tmpdir):
 
     listed_sessions = set(store.list())
     assert sessions == listed_sessions
+
+
+def test_create_directories_if_needed(tmpdir):
+    path = f"{tmpdir}/more/dirs/"
+    store = FilesystemSessionStore(path)
+    x = store.new()
+    x["foo"] = [1, 2, 3]
+    assert x.modified
+    store.save(x)


### PR DESCRIPTION
This PR is a first version for https://github.com/pallets/secure-cookie/issues/45

`FilesystemSessionStore` creates path if it doesn"t exist.
If an exception is raised during directories creation, the exception is not catched. I think it's ok but I'm not sure what you think about it according to the message in the issue.


- fixes #45


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `nox`, no tests failed.

`nox` was runned on python 3.7, 3.8 and 3.9, not 3.6.
